### PR TITLE
Changes to the documentation index page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,22 +3,21 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-nx documentation
+nx-python Documentation
 ==============================
-The nx package comes bundled with Pynx and is available for import and usage in your Python homebrew applications. It allows you to access Switch-specific elements, such as buttons, audio etc., via a high-level, object-oriented wrapper around the libnxmodule.
+The nx package comes bundled with PyNX and is available to use in your Python homebrew applications. It allows you to access Switch-specific elements, such as buttons, audio etc., via a high-level, object-oriented wrapper around libnx.
 
 Support
 ----------------------
 
 * For module specific info, try the :ref:`genindex` or :doc:`nx`.
-* For any help or further assistance please visit the `PyNX discord`_.
+* For any help or further assistance please visit the `PyNX Discord server`_.
 
 Additional Material
 ----------------------
-* `Fusee Gelee FAQ <http://www.ktemkin.com/faq-fusee-gelee/>`_
 * `libnx documentation <https://switchbrew.github.io/libnx/index.html>`_
 
-.. _PyNX discord: https://discord.gg/HDp5H4
+.. _PyNX Discord server: https://discord.gg/HDp5H4
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,22 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-nx
+nx documentation
 ==============================
-
 nx is a Python library to handle interactions with the Switch device.
+
+Support
+----------------------
+
+* For module specific info, try the :ref:`genindex` or :ref:`modindex`.
+* For any help or further assistance please visit the `PyNX discord`_.
+
+Additional Material
+----------------------
+* `Fusee Gelee FAQ <http://www.ktemkin.com/faq-fusee-gelee/>`_
+* `libnx documentation <https://switchbrew.github.io/libnx/index.html>`_
+
+.. _PyNX discord: https://discord.gg/HDp5H4
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,12 +5,12 @@
 
 nx documentation
 ==============================
-nx is a Python library to handle interactions with the Switch device.
+The nx package comes bundled with Pynx and is available for import and usage in your Python homebrew applications. It allows you to access Switch-specific elements, such as buttons, audio etc., via a high-level, object-oriented wrapper around the libnxmodule.
 
 Support
 ----------------------
 
-* For module specific info, try the :ref:`genindex` or :ref:`modindex`.
+* For module specific info, try the :ref:`genindex` or :doc:`nx`.
 * For any help or further assistance please visit the `PyNX discord`_.
 
 Additional Material

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,10 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to nx's documentation!
+nx
 ==============================
+
+nx is a Python library to handle interactions with the Switch device.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Added some intro to the index page and linked to other important places. Also changed the default theme to the read the docs standard rather than alabaster.

Now looks a bit like this:
![image](https://user-images.githubusercontent.com/4750998/40074948-02007dca-5873-11e8-9991-658622b7058f.png)
